### PR TITLE
Take job delay into consideration when calculating job age, add feature to check against # of buried jobs

### DIFF
--- a/lib/Nagios/Plugin/Beanstalk.pm
+++ b/lib/Nagios/Plugin/Beanstalk.pm
@@ -154,7 +154,7 @@ sub _check_tube {
   if (!$stats_tube or $stats_tube->current_jobs_urgent) {
     foreach my $i (1 .. 5) {
       if (my $job = $client->peek_ready) {
-        my $stats = $job->stats or return;
+        my $stats = $job->stats or next; # If job was deleted, try again
 
         # If the job got reserved between the peek and stats, then try again
         next if $stats->state eq 'reserved';


### PR DESCRIPTION
Prior to this change, if a job was delayed for 86400 seconds, once it became "ready", it would alert as being 86400 seconds old.... the delay is now subtracted from the job age in the calculation.
