### PR TITLE
Changed Nagios::Plugin to Monitoring::Plugin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+0.05 2015-10-20
+
+	Changed Nagios::Plugin to Monitoring::Plugin
+	
 0.04 2009-03-19
 
    Fix method name for fetching job priority

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,5 @@
 check_beanstalkd
-lib/Nagios/Plugin/Beanstalk.pm
+lib/Monitoring/Plugin/Beanstalk.pm
 Makefile.PL
 MANIFEST			This list of files
 MANIFEST.SKIP

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -2,7 +2,7 @@
 \B\.shipit$
 \B\.gitignore$
 \B\.DS_Store$
-^Nagios-Plugin-Beanstalk
+^Monitoring-Plugin-Beanstalk
 
 \B\.git\b
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,14 +3,14 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-  NAME         => 'Nagios::Plugin::Beanstalk',
+  NAME         => 'Monitoring::Plugin::Beanstalk',
   AUTHOR       => 'Graham Barr <gbarr@pobox.com>',
-  VERSION_FROM => 'lib/Nagios/Plugin/Beanstalk.pm',
-  ABSTRACT_FROM => 'lib/Nagios/Plugin/Beanstalk.pm',
+  VERSION_FROM => 'lib/Monitoring/Plugin/Beanstalk.pm',
+  ABSTRACT_FROM => 'lib/Monitoring/Plugin/Beanstalk.pm',
   PL_FILES     => {},
   EXE_FILES    => ['check_beanstalkd'],
   PREREQ_PM => {
-    'Nagios::Plugin' => 0,
+    'Monitoring::Plugin' => 0,
     'Beanstalk::Client' => 0,
     'Test::More' => 0,
   },

--- a/check_beanstalkd
+++ b/check_beanstalkd
@@ -5,6 +5,6 @@ eval 'exec perl -S $0 ${1+"$@"}'
 use strict;
 use warnings;
 
-use Nagios::Plugin::Beanstalk;
+use Monitoring::Plugin::Beanstalk;
 
-Nagios::Plugin::Beanstalk->new->run
+Monitoring::Plugin::Beanstalk->new->run

--- a/lib/Monitoring/Plugin/Beanstalk.pm
+++ b/lib/Monitoring/Plugin/Beanstalk.pm
@@ -1,15 +1,15 @@
-package Nagios::Plugin::Beanstalk;
+package Monitoring::Plugin::Beanstalk;
 # vim: ts=8:sw=2:expandtab
 
 use strict;
 use warnings;
 
-use base qw(Nagios::Plugin);
+use base qw(Monitoring::Plugin);
 
-use Nagios::Plugin;
+use Monitoring::Plugin;
 use Beanstalk::Client;
 
-our $VERSION = '0.04';
+our $VERSION = '0.05';
 
 
 sub new {
@@ -207,13 +207,13 @@ __END__
 
 =head1 NAME
 
-Nagios::Plugin::Beanstalk - Nagios plugin to observe Beanstalkd queue server.
+Monitoring::Plugin::Beanstalk - Monitoring plugin to observe Beanstalkd queue server.
 
 =head1 SYNOPSIS
 
-  use Nagios::Plugin::Beanstalk;
+  use Monitoring::Plugin::Beanstalk;
 
-  my $np = Nagios::Plugin::Beanstalk->new;
+  my $np = Monitoring::Plugin::Beanstalk->new;
   $np->run;
 
 =head1 DESCRIPTION

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,4 +1,4 @@
 use Test::More tests => 1;
 
-use_ok('Nagios::Plugin::Beanstalk');
+use_ok('Monitoring::Plugin::Beanstalk');
 


### PR DESCRIPTION
Please update the changes as

Nagios::Plugin - Removed from CPAN by request of Nagios Enterprises, succeeded by Monitoring::Plugin

Ref : http://search.cpan.org/dist/Nagios-Plugin/lib/Nagios/Plugin.pm
